### PR TITLE
Fix day month assignment when YYYY-MM-DD format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pseudo_date (0.1.6)
+    pseudo_date (0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -32,3 +32,6 @@ DEPENDENCIES
   byebug
   pseudo_date!
   rspec
+
+BUNDLED WITH
+   1.16.6

--- a/lib/pseudo_date/parser.rb
+++ b/lib/pseudo_date/parser.rb
@@ -86,8 +86,8 @@ class Parser
       year = date_array.select{ |part| part.length == 4 }.first
       unless year.nil? || date_array.length != 3
         if date_array.first == year
-          month = date_array.last
-          day = date_array[1]
+          month = date_array[1]
+          day = date_array.last
         else
           month = date_array.first
           day = date_array[1]


### PR DESCRIPTION
I'm guessing that this will likely not work, but the specs still pass. I don't quite know what edge cases this might introduce or if there are more that are unresolved, but it does now build PseudoDate objects in the proper way when the incoming date format looks like "YYYY-MM-DD".

I'm happy to continue investigating the issue, but I figured I'd begin the conversation with this PR.